### PR TITLE
[PXP-2318] [PXP-2666] Inherit from ancestor loggers

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -29,40 +29,74 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
-                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
             ],
-            "version": "==18.2.0"
+            "version": "==19.1.0"
+        },
+        "funcsigs": {
+            "hashes": [
+                "sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca",
+                "sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
+            ],
+            "markers": "python_version < '3.0'",
+            "version": "==1.0.2"
         },
         "more-itertools": {
             "hashes": [
-                "sha256:0125e8f60e9e031347105eb1682cef932f5e97d7b9a1a28d9bf00c22a5daef40",
-                "sha256:590044e3942351a1bdb1de960b739ff4ce277960f2425ad4509446dbace8d9d1"
+                "sha256:38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4",
+                "sha256:c0a5785b1109a6bd7fac76d6837fd1feca158e54e521ccd2ae8bfe393cc9d4fc",
+                "sha256:fe7a7cae1ccb57d33952113ff4fa1bc5f879963600ed74918f1236e212ee50b9"
             ],
-            "markers": "python_version > '2.7'",
-            "version": "==6.0.0"
+            "markers": "python_version <= '2.7'",
+            "version": "==5.0.0"
+        },
+        "pathlib2": {
+            "hashes": [
+                "sha256:25199318e8cc3c25dcb45cbe084cc061051336d5a9ea2a12448d3d8cb748f742",
+                "sha256:5887121d7f7df3603bca2f710e7219f3eca0eb69e0b7cc6e0a022e155ac931a7"
+            ],
+            "markers": "python_version < '3.6'",
+            "version": "==2.3.3"
         },
         "pluggy": {
             "hashes": [
-                "sha256:8ddc32f03971bfdf900a81961a48ccf2fb677cf7715108f85295c67405798616",
-                "sha256:980710797ff6a041e9a73a5787804f848996ecaa6f8a1b1e08224a5894f2074a"
+                "sha256:19ecf9ce9db2fce065a7a0586e07cfb4ac8614fe96edf628a264b1c70116cf8f",
+                "sha256:84d306a647cc805219916e62aab89caa97a33a1dd8c342e87a37f91073cd4746"
             ],
-            "version": "==0.8.1"
+            "version": "==0.9.0"
         },
         "py": {
             "hashes": [
-                "sha256:bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694",
-                "sha256:e76826342cefe3c3d5f7e8ee4316b80d1dd8a300781612ddbc765c17ba25a6c6"
+                "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa",
+                "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
             ],
-            "version": "==1.7.0"
+            "version": "==1.8.0"
         },
         "pytest": {
             "hashes": [
-                "sha256:80cfd9c8b9e93f419abcc0400e9f595974a98e44b6863a77d3e1039961bfc9c4",
-                "sha256:c2396a15726218a2dfef480861c4ba37bd3952ebaaa5b0fede3fc23fddcd7f8c"
+                "sha256:592eaa2c33fae68c7d75aacf042efc9f77b27c08a6224a4f59beab8d9a420523",
+                "sha256:ad3ad5c450284819ecde191a654c09b0ec72257a2c711b9633d677c71c9850c4"
             ],
             "index": "pypi",
-            "version": "==4.2.1"
+            "version": "==4.3.1"
+        },
+        "scandir": {
+            "hashes": [
+                "sha256:2586c94e907d99617887daed6c1d102b5ca28f1085f90446554abf1faf73123e",
+                "sha256:2ae41f43797ca0c11591c0c35f2f5875fa99f8797cb1a1fd440497ec0ae4b022",
+                "sha256:2b8e3888b11abb2217a32af0766bc06b65cc4a928d8727828ee68af5a967fa6f",
+                "sha256:2c712840c2e2ee8dfaf36034080108d30060d759c7b73a01a52251cc8989f11f",
+                "sha256:4d4631f6062e658e9007ab3149a9b914f3548cb38bfb021c64f39a025ce578ae",
+                "sha256:67f15b6f83e6507fdc6fca22fedf6ef8b334b399ca27c6b568cbfaa82a364173",
+                "sha256:7d2d7a06a252764061a020407b997dd036f7bd6a175a5ba2b345f0a357f0b3f4",
+                "sha256:8c5922863e44ffc00c5c693190648daa6d15e7c1207ed02d6f46a8dcc2869d32",
+                "sha256:92c85ac42f41ffdc35b6da57ed991575bdbe69db895507af88b9f499b701c188",
+                "sha256:b24086f2375c4a094a6b51e78b4cf7ca16c721dcee2eddd7aa6494b42d6d519d",
+                "sha256:cb925555f43060a1745d0a321cca94bcea927c50114b623d73179189a4e100ac"
+            ],
+            "markers": "python_version < '3.5'",
+            "version": "==1.10.0"
         },
         "six": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -4,15 +4,32 @@ Logging routines to centralize format
 Basic usage:
 ---
 
+In the parent/root module:
 ```python
 from cdislogging import get_logger
 
-logger = get_logger('my_logger')
+logger = get_logger('__name__', log_level='info')
 logger.info('Hello world!')
 ```
+In a child module:
+```python
+from cdislogging import get_logger
+
+logger = get_logger('__name__')
+logger.info('Hello world!')
+
+logger = get_logger('__name__', log_level='debug')
+logger.debug('I am a child logger but I now have my own custom log level!')
+```
+
+You _must_ set the logging level on the parent logger!
+
+The default `log_level` argument in `get_logger` is `NONE`, which means the default logging level for new loggers is `NOTSET`. This means that child loggers whose levels were not explicitly set will inherit logging levels and handlers from ancestor loggers. This makes it easier to do things like change application-wide logging levels by just setting the level on the parent logger. Levels and handlers can still be individually set on child nodes by providing a `log_level` argument.
+
+See more about Python logging [here](https://docs.python.org/3/library/logging.html).
 
 Optional parameters:
 ---
 
 * file_name (default: None) - If present, the logger will output logs to a file as well as stdout
-* log_level (default: 'debug') - Change the log level type
+* log_level (default: 'debug') - Change the log level

--- a/cdislogging/__init__.py
+++ b/cdislogging/__init__.py
@@ -83,8 +83,10 @@ def get_logger(logger_name, file_name=None, log_level=None):
             raise Exception(error_message)
 
         logger.setLevel(log_levels[log_level])
-        logger.propagate = False
     # Else if log_level is None then by default propagate=True and level=NOTSET
+
+    # TODO lol
+    logger.propagate = False
 
     if not logger.handlers:
         logger.addHandler(get_stream_handler())

--- a/cdislogging/__init__.py
+++ b/cdislogging/__init__.py
@@ -41,7 +41,9 @@ def get_file_handler(file_name):
 def get_logger(logger_name, file_name=None, log_level=None):
     """Return an opinionated basic logger named `name` that logs to stdout
 
-    If you leave the log level argument as None, the level will be set to NOTSET.
+    If you leave the log level argument as None and the logger was not
+    previously instantiated, the level will be set to NOTSET. If the logger
+    was previously instantiated, the level will be left alone.
 
     If the level is NOTSET, then ancestor loggers are traversed and searched
     for a log_level and handler. See python docs.

--- a/cdislogging/__init__.py
+++ b/cdislogging/__init__.py
@@ -71,31 +71,28 @@ def get_logger(logger_name, file_name=None, log_level=None):
         'error': logging.ERROR,     # 40
     }
 
-    if log_level is None:
-        # TODO explain
-        # This has propagate=True and level=NOTSET
-        return logging.getLogger(logger_name)
-
-    if log_level not in log_levels:
-        error_message = 'Invalid log_level parameter: {}\n\n' \
-                        'Valid options: debug, info, warning, ' \
-                        'warn, error'.format(log_level)
-        raise Exception(error_message)
-
     logger = logging.getLogger(logger_name)
 
-    logger.setLevel(log_levels[log_level])
-    logger.propagate = False
+    # TODO: Explain
 
-    # If at least one log handler exists that means it has been
+    if log_level:
+        if log_level not in log_levels:
+            error_message = 'Invalid log_level parameter: {}\n\n' \
+                            'Valid options: debug, info, warning, ' \
+                            'warn, error'.format(log_level)
+            raise Exception(error_message)
+
+        logger.setLevel(log_levels[log_level])
+        logger.propagate = False
+    # Else if log_level is None then by default propagate=True and level=NOTSET
+
+    if not logger.handlers:
+        logger.addHandler(get_stream_handler())
+
+        if file_name:
+            logger.addHandler(get_file_handler(file_name))
+    # Else if at least one log handler exists that means it has been
     # instantiated with the same name before. Do not keep creating handlers
     # or your logs will be very messy.
-    if logger.handlers:
-        return logger
-
-    logger.addHandler(get_stream_handler())
-
-    if file_name:
-        logger.addHandler(get_file_handler(file_name))
 
     return logger

--- a/cdislogging/__init__.py
+++ b/cdislogging/__init__.py
@@ -38,7 +38,9 @@ def get_file_handler(file_name):
 
     return handler
 
-def get_logger(logger_name, file_name=None, log_level='debug'):
+# TODO explain
+#def get_logger(logger_name, file_name=None, log_level='debug'):
+def get_logger(logger_name, file_name=None, log_level=None):
     """Return an opinionated basic logger named `name` that logs to stdout
 
     If you change the log level to something other than debug then it will not
@@ -69,6 +71,11 @@ def get_logger(logger_name, file_name=None, log_level='debug'):
         'error': logging.ERROR,     # 40
     }
 
+    if log_level is None:
+        # TODO explain
+        # This has propagate=True and level=NOTSET
+        return logging.getLogger(logger_name)
+
     if log_level not in log_levels:
         error_message = 'Invalid log_level parameter: {}\n\n' \
                         'Valid options: debug, info, warning, ' \
@@ -77,17 +84,18 @@ def get_logger(logger_name, file_name=None, log_level='debug'):
 
     logger = logging.getLogger(logger_name)
 
+    logger.setLevel(log_levels[log_level])
+    logger.propagate = False
+
     # If at least one log handler exists that means it has been
     # instantiated with the same name before. Do not keep creating handlers
     # or your logs will be very messy.
     if logger.handlers:
         return logger
 
-    logger.setLevel(log_levels[log_level])
     logger.addHandler(get_stream_handler())
 
     if file_name:
         logger.addHandler(get_file_handler(file_name))
 
-    logger.propagate = False
     return logger

--- a/cdislogging/__init__.py
+++ b/cdislogging/__init__.py
@@ -87,11 +87,9 @@ def get_logger(logger_name, file_name=None, log_level=None):
         logger.setLevel(log_levels[log_level])
     # Else, NOTSET is Python default.
 
-    # If propagate is true then all ancestor handlers are invoked
-    # regardless of log_level or filters
-    logger.propagate = False
+    logger.propagate = logger.level == logging.NOTSET
 
-    if log_level and not logger.handlers:
+    if logger.level != logging.NOTSET and not logger.handlers:
         logger.addHandler(get_stream_handler())
 
         if file_name:
@@ -99,5 +97,9 @@ def get_logger(logger_name, file_name=None, log_level=None):
     # Else if at least one log handler exists that means it has been
     # instantiated with the same name before. Do not keep creating handlers
     # or your logs will be very messy.
+    if logger.level == logging.NOTSET:
+        # Delete handlers in case level was set back to NOTSET
+        # after being set to something else
+        del logger.handlers[:]
 
     return logger

--- a/cdislogging/__init__.py
+++ b/cdislogging/__init__.py
@@ -38,12 +38,15 @@ def get_file_handler(file_name):
 
     return handler
 
-# TODO explain
-#def get_logger(logger_name, file_name=None, log_level='debug'):
 def get_logger(logger_name, file_name=None, log_level=None):
     """Return an opinionated basic logger named `name` that logs to stdout
 
-    If you change the log level to something other than debug then it will not
+    If you leave the log level argument as None, the level will be set to NOTSET.
+
+    If the level is NOTSET, then ancestor loggers are traversed and searched
+    for a log_level and handler. See python docs.
+
+    If you change the log level to something other than debug (or notset) then it will not
     display log statements below that level (see example and chart below for details).
     Ideally this should be handled by your application's command line args.
 
@@ -64,6 +67,7 @@ def get_logger(logger_name, file_name=None, log_level=None):
     """
 
     log_levels = {                  # sorted level
+        'notset': logging.NOTSET,   # 00
         'debug': logging.DEBUG,     # 10
         'info': logging.INFO,       # 20
         'warning': logging.WARNING, # 30
@@ -73,8 +77,6 @@ def get_logger(logger_name, file_name=None, log_level=None):
 
     logger = logging.getLogger(logger_name)
 
-    # TODO: Explain
-
     if log_level:
         if log_level not in log_levels:
             error_message = 'Invalid log_level parameter: {}\n\n' \
@@ -83,9 +85,10 @@ def get_logger(logger_name, file_name=None, log_level=None):
             raise Exception(error_message)
 
         logger.setLevel(log_levels[log_level])
-    # Else if log_level is None then by default propagate=True and level=NOTSET
+    # Else, NOTSET is Python default.
 
-    # TODO lol
+    # If propagate is true then all ancestor handlers are invoked
+    # regardless of log_level or filters
     logger.propagate = False
 
     if not logger.handlers:

--- a/cdislogging/__init__.py
+++ b/cdislogging/__init__.py
@@ -91,7 +91,7 @@ def get_logger(logger_name, file_name=None, log_level=None):
     # regardless of log_level or filters
     logger.propagate = False
 
-    if not logger.handlers:
+    if log_level and not logger.handlers:
         logger.addHandler(get_stream_handler())
 
         if file_name:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -19,6 +19,15 @@ except ImportError:
 import cdislogging
 
 
+@pytest.fixture(autouse=True)
+def delete_loggers():
+    """Delete loggers since python logging tries to reuse them"""
+    keys = logging.Logger.manager.loggerDict.keys()
+    for k in keys:
+        # Deletes logger object and dict item
+        del logging.Logger.manager.loggerDict[k]
+
+
 def test_get_stream_handler():
     handler = cdislogging.get_stream_handler()
     assert handler.formatter._fmt == cdislogging.FORMAT
@@ -75,17 +84,16 @@ def test_instantiate_with_log_level():
     assert len(logger.handlers) == 1
 
 
-#def test_instantiate_without_log_level():
-#    """
-#    Check that if logger instantiated without log_level arg
-#    then level and propagate are set correctly and no handlers created
-#    """
-#    # TODO: Shoot, this thing gets the logger from the previous test hahaha
-#    logger = cdislogging.get_logger('logger')
-#    assert logger.level == logging.NOTSET
-#    assert logger.propagate == True
-#    assert len(logger.handlers) == 0
-#
+def test_instantiate_without_log_level():
+    """
+    Check that if logger instantiated without log_level arg
+    then level and propagate are set correctly and no handlers created
+    """
+    logger = cdislogging.get_logger('logger')
+    assert logger.level == logging.NOTSET
+    assert logger.propagate == True
+    assert len(logger.handlers) == 0
+
 
 def test_log_level():
     """

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -22,7 +22,7 @@ import cdislogging
 @pytest.fixture(autouse=True)
 def delete_loggers():
     """Delete loggers since python logging tries to reuse them"""
-    keys = logging.Logger.manager.loggerDict.keys()
+    keys = list(logging.Logger.manager.loggerDict.keys())
     for k in keys:
         # Deletes logger object and dict item
         del logging.Logger.manager.loggerDict[k]

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -18,9 +18,11 @@ except ImportError:
 
 import cdislogging
 
+
 def test_get_stream_handler():
     handler = cdislogging.get_stream_handler()
     assert handler.formatter._fmt == cdislogging.FORMAT
+
 
 def test_get_file_handler():
     file_name = 'FAKE-LOGGER.TXT'
@@ -33,10 +35,12 @@ def test_get_file_handler():
     if os.path.exists(file_name):
         os.remove(file_name)
 
+
 def test_get_logger():
     log_name = 'test_get_logger'
     logger = cdislogging.get_logger(log_name)
     assert logger.name == log_name
+
 
 log_levels = [
     ('debug', logging.DEBUG),
@@ -50,6 +54,7 @@ def test_get_logger_log_levels(given, expected):
     logger = cdislogging.get_logger('test_get_logger_log_levels' + given, log_level=given)
     assert logger.getEffectiveLevel() == expected
 
+
 def test_multiple_log_handlers():
     logger = cdislogging.get_logger('one_handler', log_level='debug')
     assert len(logger.handlers) == 1
@@ -58,61 +63,190 @@ def test_multiple_log_handlers():
     logger = cdislogging.get_logger('one_handler', log_level='debug')
     assert len(logger.handlers) == 1
 
-def test_inheritance():
+
+def test_instantiate_with_log_level():
+    """
+    Check that if logger instantiated with log_level != NOTSET
+    then level and propagate are set correctly and handler is created
+    """
+    logger = cdislogging.get_logger('logger', log_level='info')
+    assert logger.level == logging.INFO
+    assert logger.propagate == False
+    assert len(logger.handlers) == 1
+
+
+#def test_instantiate_without_log_level():
+#    """
+#    Check that if logger instantiated without log_level arg
+#    then level and propagate are set correctly and no handlers created
+#    """
+#    # TODO: Shoot, this thing gets the logger from the previous test hahaha
+#    logger = cdislogging.get_logger('logger')
+#    assert logger.level == logging.NOTSET
+#    assert logger.propagate == True
+#    assert len(logger.handlers) == 0
+#
+
+def test_log_level():
+    """
+    Check that logger with level != NOTSET correctly logs according to own level
+    """
+    logger = cdislogging.get_logger('logger', log_level='info')
+    mock_logger_hdlr_emit = MagicMock()
+    logger.handlers[0].emit = mock_logger_hdlr_emit
+
+    logger.info("Should emit")
+    assert mock_logger_hdlr_emit.call_count == 1
+
+    logger.debug("Should not emit")
+    assert mock_logger_hdlr_emit.call_count == 1
+
+
+def test_log_level_changes():
+    """
+    Check that logger responds to changes in own log level
+    """
+    logger = cdislogging.get_logger('logger', log_level='info')
+    mock_logger_hdlr_emit = MagicMock()
+    logger.handlers[0].emit = mock_logger_hdlr_emit
+
+    logger.debug("Should not emit")
+    assert mock_logger_hdlr_emit.call_count == 0
+
+    cdislogging.get_logger('logger', log_level='debug')
+
+    logger.debug("Should now emit")
+    assert mock_logger_hdlr_emit.call_count == 1
+
+
+def test_child_inherits_parent_level():
+    """
+    Check that child logger with level NOTSET will log according to parent level
+    """
     parent = cdislogging.get_logger('parent', log_level='info')
-    assert parent.propagate == False
-    assert len(parent.handlers) == 1
-
-    child = cdislogging.get_logger('parent.child')
-    assert child.propagate == True
-    assert len(child.handlers) == 0
-
     mock_parent_hdlr_emit = MagicMock()
     parent.handlers[0].emit = mock_parent_hdlr_emit
+
+    child = cdislogging.get_logger('parent.child') # No handlers
 
     child.info("Should emit via parent")
     assert mock_parent_hdlr_emit.call_count == 1
     child.debug("Should not emit since parent level is info and child level is notset")
     assert mock_parent_hdlr_emit.call_count == 1
 
-    parent = cdislogging.get_logger('parent', log_level='debug')
 
-    child.info("Should emit via parent")
-    assert mock_parent_hdlr_emit.call_count == 2
-    child.debug("Should emit via parent since parent level changed to debug and child level is notset")
-    assert mock_parent_hdlr_emit.call_count == 3
+def test_child_inherits_parent_level_changes():
+    """
+    Check that child logger with level NOTSET will respond to changes in parent log level
+    """
+    parent = cdislogging.get_logger('parent', log_level='info')
+    mock_parent_hdlr_emit = MagicMock()
+    parent.handlers[0].emit = mock_parent_hdlr_emit
 
-    child = cdislogging.get_logger('parent.child', log_level='warn')
+    child = cdislogging.get_logger('parent.child') # No handlers
+
+    child.debug("should not emit since parent level is info")
+    assert mock_parent_hdlr_emit.call_count == 0
+
+    cdislogging.get_logger('parent', log_level='debug')
+
+    child.debug("should now emit")
+    assert mock_parent_hdlr_emit.call_count == 1
+
+
+def test_child_change_level_from_notset_updates_properties():
+    """
+    Check that if a child logger was instantiated with level NOTSET
+    and then get_logger() is called on it with a log_level arg != 'notset',
+    the child logger correctly updates level and propagate,
+    and gets its own handler
+    """
+    parent = cdislogging.get_logger('parent', log_level='info')
+    child = cdislogging.get_logger('parent.child')
+    assert child.propagate == True
+    assert len(child.handlers) == 0
+
+    # TODO: should really rename this to get_or_update_logger...
+    cdislogging.get_logger('parent.child', log_level='warn')
+
     assert child.propagate == False
     assert len(child.handlers) == 1
 
+
+def test_child_change_level_from_notset_logs_own_level():
+    """
+    Check that if a child logger was instantiated with level NOTSET
+    and then get_logger() is called on it with a log_level arg != 'notset',
+    the child logger correctly logs at its own new level
+    on its own new handler
+    """
+    parent = cdislogging.get_logger('parent', log_level='info')
+    mock_parent_hdlr_emit = MagicMock()
+    parent.handlers[0].emit = mock_parent_hdlr_emit
+
+    child = cdislogging.get_logger('parent.child')
+
+    cdislogging.get_logger('parent.child', log_level='warn')
     mock_child_hdlr_emit = MagicMock()
     child.handlers[0].emit = mock_child_hdlr_emit
 
-    parent.warn("Should emit with parent hdlr since this is the parent")
-    assert mock_parent_hdlr_emit.call_count == 4
-    assert mock_child_hdlr_emit.call_count == 0
-
-    child.info("Should not emit at all since child level is now warn")
-    assert mock_parent_hdlr_emit.call_count == 4
-    assert mock_child_hdlr_emit.call_count == 0
-
-    child.warn("Should emit with child hdlr only since child level was set; no longer inherits")
-    assert mock_parent_hdlr_emit.call_count == 4
+    child.warn("Should emit with child hdlr only; child no longer inherits/propagates")
+    assert mock_parent_hdlr_emit.call_count == 0
     assert mock_child_hdlr_emit.call_count == 1
 
-    # Check that calling get_logger again with no log_level arg after logger was instantiated
-    # does _not_ reset the log level to NOTSET
-    child = cdislogging.get_logger('parent.child')
-    # Parent level is debug, child level is warn:
-    child.debug("Should not emit, but will emit if child level was reset to notset")
-    assert mock_parent_hdlr_emit.call_count == 4
+    child.info("Should not emit; child level is now warn")
+    assert mock_parent_hdlr_emit.call_count == 0
     assert mock_child_hdlr_emit.call_count == 1
+
+
+def test_reset_to_notset():
+    """
+    Check that if logger was instantiated with log_level != NOTSET
+    and then get_logger() is called on it again with log_level='notset',
+    the logger's log level is correctly reset to NOTSET
+    and the logger logs at the correct level
+    """
+    parent = cdislogging.get_logger('parent', log_level='debug')
+    mock_parent_hdlr_emit = MagicMock()
+    parent.handlers[0].emit = mock_parent_hdlr_emit
+
+    child = cdislogging.get_logger('parent.child', log_level='info')
+    mock_child_hdlr_emit = MagicMock()
+    child.handlers[0].emit = mock_child_hdlr_emit
 
     child = cdislogging.get_logger('parent.child', log_level='notset')
     assert child.propagate == True
     assert len(child.handlers) == 0
 
-    child.info("Should emit with parent hdlr only since level was reset to notset")
-    assert mock_parent_hdlr_emit.call_count == 5
+    child.info("Should emit with parent hdlr only")
+    assert mock_parent_hdlr_emit.call_count == 1
+    assert mock_child_hdlr_emit.call_count == 0
+
+    child.debug("Should emit with parent hdlr only")
+    assert mock_parent_hdlr_emit.call_count == 2
+    assert mock_child_hdlr_emit.call_count == 0
+
+
+def test_no_unintentional_reset_to_notset():
+    """
+    Check that if logger was instantiated with log_level != NOTSET
+    and then get_logger() is called on it again without a log_level arg,
+    the logger's log level does _not_ get reset to NOTSET
+    """
+    parent = cdislogging.get_logger('parent', log_level='debug')
+    mock_parent_hdlr_emit = MagicMock()
+    parent.handlers[0].emit = mock_parent_hdlr_emit
+
+    child = cdislogging.get_logger('parent.child', log_level='info')
+    mock_child_hdlr_emit = MagicMock()
+    child.handlers[0].emit = mock_child_hdlr_emit
+
+    child.info("Sanity check that this will emit on child hdlr")
+    assert mock_parent_hdlr_emit.call_count == 0
+    assert mock_child_hdlr_emit.call_count == 1
+
+    child = cdislogging.get_logger('parent.child')
+    child.debug("Should not emit, but will emit on parent hdlr if child level was reset to NOTSET")
+
+    assert mock_parent_hdlr_emit.call_count == 0
     assert mock_child_hdlr_emit.call_count == 1

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -67,44 +67,44 @@ def test_inheritance():
     assert child.propagate == True
     assert len(child.handlers) == 0
 
-    mock_parent_hdlr = MagicMock()
-    parent.handlers[0].emit = mock_parent_hdlr
+    mock_parent_hdlr_emit = MagicMock()
+    parent.handlers[0].emit = mock_parent_hdlr_emit
 
-    child.info("Should emit")
-    assert mock_parent_hdlr.call_count == 1
-    child.debug("Should not emit")
-    assert mock_parent_hdlr.call_count == 1
+    child.info("Should emit via parent")
+    assert mock_parent_hdlr_emit.call_count == 1
+    child.debug("Should not emit since parent level is info and child level is notset")
+    assert mock_parent_hdlr_emit.call_count == 1
 
     parent = cdislogging.get_logger('parent', log_level='debug')
 
-    child.info("Should emit")
-    assert mock_parent_hdlr.call_count == 2
-    child.debug("Should emit")
-    assert mock_parent_hdlr.call_count == 3
+    child.info("Should emit via parent")
+    assert mock_parent_hdlr_emit.call_count == 2
+    child.debug("Should emit via parent since parent level changed to debug and child level is notset")
+    assert mock_parent_hdlr_emit.call_count == 3
 
     child = cdislogging.get_logger('parent.child', log_level='warn')
     assert child.propagate == False
     assert len(child.handlers) == 1
 
-    mock_child_hdlr = MagicMock()
-    child.handlers[0].emit = mock_child_hdlr
+    mock_child_hdlr_emit = MagicMock()
+    child.handlers[0].emit = mock_child_hdlr_emit
 
-    parent.warn("Should emit with parent hdlr")
-    assert mock_parent_hdlr.call_count == 4
-    assert mock_child_hdlr.call_count == 0
+    parent.warn("Should emit with parent hdlr since this is the parent")
+    assert mock_parent_hdlr_emit.call_count == 4
+    assert mock_child_hdlr_emit.call_count == 0
 
-    child.info("Should not emit at all")
-    assert mock_parent_hdlr.call_count == 4
-    assert mock_child_hdlr.call_count == 0
+    child.info("Should not emit at all since child level is now warn")
+    assert mock_parent_hdlr_emit.call_count == 4
+    assert mock_child_hdlr_emit.call_count == 0
 
-    child.warn("Should emit with child hdlr only")
-    assert mock_parent_hdlr.call_count == 4
-    assert mock_child_hdlr.call_count == 1
+    child.warn("Should emit with child hdlr only since child level was set; no longer inherits")
+    assert mock_parent_hdlr_emit.call_count == 4
+    assert mock_child_hdlr_emit.call_count == 1
 
     child = cdislogging.get_logger('parent.child', log_level='notset')
     assert child.propagate == True
     assert len(child.handlers) == 0
 
-    child.info("Should emit with parent hdlr only")
-    assert mock_parent_hdlr.call_count == 5
-    assert mock_child_hdlr.call_count == 1
+    child.info("Should emit with parent hdlr only since level was reset to notset")
+    assert mock_parent_hdlr_emit.call_count == 5
+    assert mock_child_hdlr_emit.call_count == 1

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -43,9 +43,9 @@ def test_get_logger_log_levels(given, expected):
     assert logger.getEffectiveLevel() == expected
 
 def test_multiple_log_handlers():
-    logger = cdislogging.get_logger('one_handler')
+    logger = cdislogging.get_logger('one_handler', log_level='debug')
     assert len(logger.handlers) == 1
 
     # make sure it only has one handler associated with the logger name
-    logger = cdislogging.get_logger('one_handler')
+    logger = cdislogging.get_logger('one_handler', log_level='debug')
     assert len(logger.handlers) == 1

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -101,6 +101,14 @@ def test_inheritance():
     assert mock_parent_hdlr_emit.call_count == 4
     assert mock_child_hdlr_emit.call_count == 1
 
+    # Check that calling get_logger again with no log_level arg after logger was instantiated
+    # does _not_ reset the log level to NOTSET
+    child = cdislogging.get_logger('parent.child')
+    # Parent level is debug, child level is warn:
+    child.debug("Should not emit, but will emit if child level was reset to notset")
+    assert mock_parent_hdlr_emit.call_count == 4
+    assert mock_child_hdlr_emit.call_count == 1
+
     child = cdislogging.get_logger('parent.child', log_level='notset')
     assert child.propagate == True
     assert len(child.handlers) == 0

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -8,6 +8,14 @@ import logging
 
 import pytest
 
+# Python 2 and 3 compatible
+try:
+    from unittest.mock import MagicMock
+    from unittest.mock import patch
+except ImportError:
+    from mock import MagicMock
+    from mock import patch
+
 import cdislogging
 
 def test_get_stream_handler():
@@ -49,3 +57,54 @@ def test_multiple_log_handlers():
     # make sure it only has one handler associated with the logger name
     logger = cdislogging.get_logger('one_handler', log_level='debug')
     assert len(logger.handlers) == 1
+
+def test_inheritance():
+    parent = cdislogging.get_logger('parent', log_level='info')
+    assert parent.propagate == False
+    assert len(parent.handlers) == 1
+
+    child = cdislogging.get_logger('parent.child')
+    assert child.propagate == True
+    assert len(child.handlers) == 0
+
+    mock_parent_hdlr = MagicMock()
+    parent.handlers[0].emit = mock_parent_hdlr
+
+    child.info("Should emit")
+    assert mock_parent_hdlr.call_count == 1
+    child.debug("Should not emit")
+    assert mock_parent_hdlr.call_count == 1
+
+    parent = cdislogging.get_logger('parent', log_level='debug')
+
+    child.info("Should emit")
+    assert mock_parent_hdlr.call_count == 2
+    child.debug("Should emit")
+    assert mock_parent_hdlr.call_count == 3
+
+    child = cdislogging.get_logger('parent.child', log_level='warn')
+    assert child.propagate == False
+    assert len(child.handlers) == 1
+
+    mock_child_hdlr = MagicMock()
+    child.handlers[0].emit = mock_child_hdlr
+
+    parent.warn("Should emit with parent hdlr")
+    assert mock_parent_hdlr.call_count == 4
+    assert mock_child_hdlr.call_count == 0
+
+    child.info("Should not emit at all")
+    assert mock_parent_hdlr.call_count == 4
+    assert mock_child_hdlr.call_count == 0
+
+    child.warn("Should emit with child hdlr only")
+    assert mock_parent_hdlr.call_count == 4
+    assert mock_child_hdlr.call_count == 1
+
+    child = cdislogging.get_logger('parent.child', log_level='notset')
+    assert child.propagate == True
+    assert len(child.handlers) == 0
+
+    child.info("Should emit with parent hdlr only")
+    assert mock_parent_hdlr.call_count == 5
+    assert mock_child_hdlr.call_count == 1


### PR DESCRIPTION
The default log_level argument in get_logger is now NONE, which means the default level for new loggers is NOTSET. This means that child loggers whose levels were not explicitly set will inherit logging levels and handlers from ancestor loggers. This makes it easier to do things like toggle application-wide logging levels by just setting the level on the parent. Levels and handlers can still be set on child nodes by providing the log_level argument. // So now, for example, in a parent module you can do: `logger = get_logger(__name__, log_level='debug')`, and in child modules do `logger = get_logger(__name__)`, and the child loggers will just inherit from the parent. Or, set a custom level for a child logger if desired; just supply `log_level` in the child instantiation. //  https://docs.python.org/3/library/logging.html

Note: update this https://github.com/uc-cdis/authutils/releases wherever you update cdislogging


### New Features


### Breaking Changes
Default log_level arg in get_logger is now NONE; now you must explicitly set the log_level on the parent logger


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

