### PR TITLE
chore(logging): Remove arbitrary spaces from log entries

### DIFF
--- a/cdislogging/__init__.py
+++ b/cdislogging/__init__.py
@@ -7,7 +7,7 @@ import logging
 import sys
 
 
-FORMAT = '[%(asctime)s][%(name)10s][%(levelname)7s] %(message)s'
+FORMAT = '[%(asctime)s][%(name)s][%(levelname)s] %(message)s'
 
 def get_stream_handler():
     """Return a stdout stream handler


### PR DESCRIPTION
Testing:
```
cdislogging [master●] % python setup.py install
cdislogging [master●] % cat test.py
from cdislogging import get_logger
logger = get_logger("mytest", log_level="info")
logger.info('hello world')
--
cdislogging [master●] % python test.py
[2020-02-13 16:12:32,236][    mytest][   INFO] hello world
--
cdislogging [master●●] % grep "^FORMAT" cdislogging/__init__.py
FORMAT = '[%(asctime)s][%(name)s][%(levelname)s] %(message)s'
cdislogging [master●●] % python test.py
[2020-02-13 16:18:11,473][mytest][INFO] hello world
```